### PR TITLE
Add option to filter for movie genres.

### DIFF
--- a/plugin.video.filmfriend.de/default.py
+++ b/plugin.video.filmfriend.de/default.py
@@ -12,6 +12,7 @@ class filmfriend(lm4):
 			'listMain': self.listMain,
 			'listVideos': self.listVideos,
 			'listWatchList': self.listWatchList,
+			'listGenres': self.listGenres,
 		})
 
 		self.searchModes = {
@@ -26,12 +27,21 @@ class filmfriend(lm4):
 		l = []
 		l.append({'metadata':{'name':self.translation(32030)}, 'type':'dir', 'params':{'mode':'listSearch', 'content':'videos',  'params':'?facets=Kind&facets=VideoKind&facets=Categories&facets=Genres&facets=GameSituations&facets=AgeRecommendation&facets=AudioLanguages&facets=AudioDescriptionLanguages&facets=SubtitleLanguages&facets=ClosedCaptionLanguages&kinds=Video&kinds=Series&videoKinds=Movie&&&&orderBy=ActiveSinceDateTime&sortDirection=Descending&skip=0&take=20'}})
 		l.append({'metadata':{'name':self.translation(32031)}, 'type':'dir', 'params':{'mode':'listSearch', 'content':'videos',  'params':'?facets=Kind&facets=VideoKind&facets=Categories&facets=Genres&facets=GameSituations&facets=AgeRecommendation&facets=AudioLanguages&facets=AudioDescriptionLanguages&facets=SubtitleLanguages&facets=ClosedCaptionLanguages&kinds=Video&videoKinds=Movie&&&&orderBy=MonthlyImpressionScore&sortDirection=Descending&skip=0&take=20'}})
+		l.append({'metadata':{'name': 'Genres'}, 'type':'dir', 'params':{'mode':'listGenres', 'content':'videos',  'params':'?totalCount=true&take=500&sortOrder=RecentlyAdded'}})
 		l.append({'metadata':{'name':self.translation(30600)}, 'type':'dir', 'params':{'mode':'listSearch', 'content':'tvshows', 'params':'?facets=Kind&facets=VideoKind&facets=Categories&facets=Genres&facets=GameSituations&facets=AgeRecommendation&facets=AudioLanguages&facets=AudioDescriptionLanguages&facets=SubtitleLanguages&facets=ClosedCaptionLanguages&kinds=Series&&languageIsoCode=EN&orderBy=EnglishOrder&sortDirection=Ascending&skip=0&take=500'}})
 		l.append({'metadata':{'name':self.translation(30601)}, 'type':'dir', 'params':{'mode':'listSearch', 'content':'movies',  'params':'?facets=Kind&facets=VideoKind&facets=Categories&facets=Genres&facets=GameSituations&facets=AgeRecommendation&facets=AudioLanguages&facets=AudioDescriptionLanguages&facets=SubtitleLanguages&facets=ClosedCaptionLanguages&kinds=Video&videoKinds=Movie&categories=d36cbed2-7569-4b94-9080-03ce79c2ecee&orderBy=EnglishOrder&sortDirection=Ascending&skip=0&take=500'}})
 		l.append({'metadata':{'name':self.translation(30602)}, 'type':'dir', 'params':{'mode':'listWatchList', 'content':'videos',  'params':'?totalCount=true&take=500&sortOrder=RecentlyAdded'}})
 		l.append({'metadata':{'name':self.translation(32139)}, 'params':{'mode':'libMediathekSearch', 'searchMode':'listVideoSearch'}, 'type':'dir'})
 		return {'items':l,'name':'root'}
 
+	def listGenres(self):
+		genre_names, genre_ids = jsonParser.parseGenres()
+		l = []
+		for genre_name, genre_id in zip(genre_names, genre_ids):
+			l.append({'metadata':{'name': genre_name}, 'type':'dir', 'params':{'mode':'listSearch', 'content':'videos',  'params': f'?facets=Kind&facets=VideoKind&facets=Categories&facets=Genres&facets=GameSituations&facets=AgeRecommendation&facets=AudioLanguages&facets=AudioDescriptionLanguages&facets=SubtitleLanguages&facets=ClosedCaptionLanguages&kinds=Video&kinds=Series&videoKinds=Movie&genres={genre_id}&&&orderBy=EnglishOrder&sortDirection=Ascending&skip=0&take=500'}})
+		
+		return {'items':l}
+    
 	def listSearch(self):
 		return jsonParser.parseSearch(self.params['params'],self.params['content'])
 

--- a/plugin.video.filmfriend.de/resources/lib/jsonparser.py
+++ b/plugin.video.filmfriend.de/resources/lib/jsonparser.py
@@ -89,6 +89,18 @@ def fetchJson(url,headers=None):
 def parseMain():
 	j = requests.get(f'{base}tenant-groups/21960588-0518-4dd3-89e5-f25ba5bf5631/navigation').json()
 
+def parseGenres():
+	# get list of genres
+	tenant = lm4utils.getSetting("tenant")
+	response_genres = requests.get(f'https://api.tenant.frontend.vod.filmwerte.de/v11/{tenant}/genres')
+	genre_names = []
+	genre_ids = []
+	if response_genres.status_code == 200:
+		genres = response_genres.json()
+		genre_names = [d["name"] for d in genres]
+		genre_ids = [d["id"] for d in genres]
+	return genre_names, genre_ids
+
 def parseWatchList(params,content='videos'):
 	_checkTokenExpired()
 	token = lm4utils.getTokenWithErrorNotification()


### PR DESCRIPTION
This pull request introduces a new feature to the main menu, allowing users to filter movies by different genres. The proposed changes add an additional menu item that, when selected, displays a list of (predefined) genres. Users can then choose a genre to view a curated selection of movies that match their chosen category. This enhances the navigation experience and helps users find movies based on their preferences more efficiently.